### PR TITLE
fakechroot fix unshare replacement

### DIFF
--- a/package/fakechroot/arch-chroot.env
+++ b/package/fakechroot/arch-chroot.env
@@ -10,9 +10,9 @@ fi
 fakechroot_arch_chroot_env_cmd_subst="$(which mount || echo /usr/bin/mount)=/usr/bin/true
 $(which umount || echo /usr/bin/umount)=/usr/bin/true
 $(which ldconfig || echo /usr/bin/ldconfig)=/usr/bin/true
-$(which ldd || echo /usr/bin/ldd)=${fakechroot_bindir:-/usr/bin}/ldd.fakechroot
-$(which unshare || echo /usr/bin/unshare)=${fakechroot_bindir:-/usr/bin}/unshare.fakechroot
-$(which chroot || echo /usr/sbin/chroot)=${fakechroot_bindir:-/usr/sbin}/chroot.fakechroot"
+$(which ldd || echo /usr/bin/ldd)=${fakechroot_bindir:-/usr/local/bin}/ldd.fakechroot
+$(which unshare || echo /usr/bin/unshare)=${fakechroot_bindir:-/usr/local/bin}/unshare.fakechroot
+$(which chroot || echo /usr/sbin/chroot)=${fakechroot_bindir:-/usr/local/bin}/chroot.fakechroot"
 
 FAKECHROOT_CMD_SUBST="${FAKECHROOT_CMD_SUBST:+$FAKECHROOT_CMD_SUBST:}`echo \"$fakechroot_arch_chroot_env_cmd_subst\" | tr '\012' ':'`"
 export FAKECHROOT_CMD_SUBST

--- a/package/fakechroot/fakechroot.mk
+++ b/package/fakechroot/fakechroot.mk
@@ -13,6 +13,7 @@ define HOST_FAKECHROOT_INSTALL_CMDS
 	$(HOST_MAKE_ENV) $(MAKE) install -C $(@D)
 	$(INSTALL) -D -m644 $(HOST_FAKECHROOT_PKGDIR)/pacstrap.env $(HOST_DIR)/etc/fakechroot/pacstrap.env
 	$(INSTALL) -D -m644 $(HOST_FAKECHROOT_PKGDIR)/arch-chroot.env $(HOST_DIR)/etc/fakechroot/arch-chroot.env
+	$(INSTALL) -D -m755 $(HOST_FAKECHROOT_PKGDIR)/unshare.fakechroot.sh $(HOST_DIR)/bin/unshare.fakechroot
 	$(SED) 's,/usr/local,$(HOST_DIR),' $(HOST_DIR)/etc/fakechroot/pacstrap.env
 endef
 

--- a/package/fakechroot/fakechroot.mk
+++ b/package/fakechroot/fakechroot.mk
@@ -15,6 +15,7 @@ define HOST_FAKECHROOT_INSTALL_CMDS
 	$(INSTALL) -D -m644 $(HOST_FAKECHROOT_PKGDIR)/arch-chroot.env $(HOST_DIR)/etc/fakechroot/arch-chroot.env
 	$(INSTALL) -D -m755 $(HOST_FAKECHROOT_PKGDIR)/unshare.fakechroot.sh $(HOST_DIR)/bin/unshare.fakechroot
 	$(SED) 's,/usr/local,$(HOST_DIR),' $(HOST_DIR)/etc/fakechroot/pacstrap.env
+	$(SED) 's,/usr/local,$(HOST_DIR),' $(HOST_DIR)/etc/fakechroot/arch-chroot.env
 endef
 
 $(eval $(host-autotools-package))

--- a/package/fakechroot/pacstrap.env
+++ b/package/fakechroot/pacstrap.env
@@ -10,9 +10,9 @@ fi
 fakechroot_pacstrap_env_cmd_subst="$(which mount || echo /usr/bin/mount)=/usr/bin/true
 $(which umount || echo /usr/bin/umount)=/usr/bin/true
 $(which ldconfig || echo /usr/bin/ldconfig)=/usr/bin/true
-$(which ldd || echo /usr/bin/ldd)=${fakechroot_bindir:-/usr/bin}/ldd.fakechroot
-$(which unshare || echo /usr/bin/unshare)=${fakechroot_bindir:-/usr/bin}/unshare.fakechroot
-$(which chroot || echo /usr/sbin/chroot)=${fakechroot_bindir:-/usr/sbin}/chroot.fakechroot"
+$(which ldd || echo /usr/bin/ldd)=${fakechroot_bindir:-/usr/local/bin}/ldd.fakechroot
+$(which unshare || echo /usr/bin/unshare)=${fakechroot_bindir:-/usr/local/bin}/unshare.fakechroot
+$(which chroot || echo /usr/sbin/chroot)=${fakechroot_bindir:-/usr/local/bin}/chroot.fakechroot"
 
 FAKECHROOT_CMD_SUBST="${FAKECHROOT_CMD_SUBST:+$FAKECHROOT_CMD_SUBST:}`echo \"$fakechroot_pacstrap_env_cmd_subst\" | tr '\012' ':'`"
 export FAKECHROOT_CMD_SUBST

--- a/package/fakechroot/unshare.fakechroot.sh
+++ b/package/fakechroot/unshare.fakechroot.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# unshare
+#
+# Replacement for unshare command which calls program directly.
+#
+# (c) 2020 Gaël PORTAY <gael.portay@gmail.com>, LGPL
+
+SHELL="${SHELL:-/bin/sh}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -*)
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+exec "${@:-$SHELL}"


### PR DESCRIPTION
This fixes the error below:

```
==> Creating install root at rootfs
==> Installing packages to rootfs
/home/user/src/linux-distros-br2-external/buildroot/output/host/bin/pacstrap: line 372: /usr/bin/unshare: No such file or directory
==> ERROR: Failed to install packages to new root
```