### PR TITLE
Alpine Linux run apk fix if broken

### DIFF
--- a/board/alpinelinux/overlay/etc/init.d/apk-fix
+++ b/board/alpinelinux/overlay/etc/init.d/apk-fix
@@ -1,0 +1,23 @@
+#!/sbin/openrc-run
+#
+#  SPDX-License-Identifier: GPL-2.0+
+#
+#  This file is part of linux-distros-br2-external.
+#
+#  linux-distros-br2-external is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2.0 of the License, or (at your
+#  option) any later version.
+
+depend() {
+	need network-online
+	after network-online
+}
+
+start() {
+	ebegin "Fixing apk (postinst's workaround)"
+	if apk fix; then
+		rm -f /etc/runlevels/*/$RC_SVCNAME
+	fi
+	eend $?
+}

--- a/board/alpinelinux/post-build.sh
+++ b/board/alpinelinux/post-build.sh
@@ -67,6 +67,9 @@ EOF
 	fi
 fi
 
+# Fix https://github.com/OpenRC/openrc/pull/391
+sed -e '/[ -h "${ifname}" ] && continue/s,&&,||,' -i "$TARGET_DIR/etc/init.d/net-online"
+
 mkdir -p "${TARGET_DIR}/etc/runlevels/"{boot,sysinit,default,shutdown}
 ln -sf /etc/init.d/{modules,sysctl,hostname,bootmisc,syslog} "$TARGET_DIR/etc/runlevels/boot/"
 ln -sf /etc/init.d/{devfs,dmesg,mdev,hwdrivers} "${TARGET_DIR}/etc/runlevels/sysinit/"

--- a/board/alpinelinux/post-build.sh
+++ b/board/alpinelinux/post-build.sh
@@ -72,3 +72,8 @@ ln -sf /etc/init.d/{modules,sysctl,hostname,bootmisc,syslog} "$TARGET_DIR/etc/ru
 ln -sf /etc/init.d/{devfs,dmesg,mdev,hwdrivers} "${TARGET_DIR}/etc/runlevels/sysinit/"
 ln -sf /etc/init.d/{networking,ntpd} "${TARGET_DIR}/etc/runlevels/default/"
 ln -sf /etc/init.d/{mount-ro,killprocs,savecache} "${TARGET_DIR}/etc/runlevels/shutdown/"
+
+if grep -q "^f=" "${TARGET_DIR}/lib/apk/installed"
+then
+	ln -sf /etc/init.d/apk-fix "${TARGET_DIR}/etc/runlevels/default/"
+fi


### PR DESCRIPTION
[Alpine Linux] does not have support yet for [fakechroot], because it does not compile with the [musl] libc.

As a consequence, the package scripts (preinst, postinst, trigger) can succeed or fail in case of emulation (target and host have different architectures) because the fakechroot environment is not set.

Even if the package scripts succeed, nothing guarantees that things run correctly and there is nothing to do but to port fakechroot to musl and create a package.

In the meanwhile, `apk-tools` accepts that the trigger scripts fails and flag the packages as [broken] in the database `/lib/apk/db/installed`. Every subsequent calls to `apk` return failure as long as it is not fixed by `apk fix`.

This introduces the init-script `apk-fix` that is added at run-level networking if the database is broken. It downloads again the packages, thus it runs after `net-online` and it removes itself from all run-levels on success.

Note: It backports a net-online fix from the OpenRC's [PR391].

[Alpine Linux]: https://pkgs.alpinelinux.org/packages?name=fakechroot&branch=edge
[fakechroot]: https://github.com/dex4er/fakechroot
[musl]: https://musl.libc.org
[broken]: https://github.com/alpinelinux/apk-tools/blob/a2fa544ac6a75f93d809e3457432618dd89376dd/src/database.c#L924-L931
[PR391]: https://github.com/OpenRC/openrc/pull/391